### PR TITLE
Remove parentheses around keywords in the initial ANOMALY_KEYWORDS list

### DIFF
--- a/training_controller/main.py
+++ b/training_controller/main.py
@@ -158,6 +158,7 @@ async def train_model():
         max_logs_for_training = PrepareTrainingLogs().get_num_logs_for_training()
         end_ts = int(time.time() * 1000)
         start_ts = end_ts - TRAINING_DATA_INTERVAL
+        parentheses_keywords = [f"({ANOMALY_KEYWORDS})"]
         model_logs_query_body = {
             "query": {
                 "bool": {
@@ -196,7 +197,9 @@ async def train_model():
                     )
         # This function handles get requests for fetching pod,namespace and workload breakdown insights.
         logging.info(f"Received request to train model.")
-        training_data_count = (await es_instance.count(index="logs", body=model_logs_query_body))["count"]
+        training_data_count = (
+            await es_instance.count(index="logs", body=model_logs_query_body)
+        )["count"]
         payload_query = {
             "max_size": max_logs_for_training,
             "query": model_logs_query_body,

--- a/training_controller/main.py
+++ b/training_controller/main.py
@@ -46,6 +46,7 @@ gpu_training_request = 0
 last_trainingjob_time = 0
 workload_parameters_dict = dict()
 GPU_GATEWAY_ENDPOINT = "http://opni-internal:11080/ModelTraining/gpu_info"
+TRAINING_DATA_INTERVAL = 3600 * 1000 * 24 # unit: ms. With introducing streaming data loader, it's possible to download much more training data.
 
 
 def get_gpu_status():
@@ -142,7 +143,7 @@ async def train_model():
     if gpu_training_request == 0:
         max_logs_for_training = PrepareTrainingLogs().get_num_logs_for_training()
         end_ts = int(time.time() * 1000)
-        start_ts = end_ts - 3600000
+        start_ts = end_ts - TRAINING_DATA_INTERVAL
         model_logs_query_body = {
             "query": {
                 "bool": {
@@ -173,12 +174,15 @@ async def train_model():
                     )
         # This function handles get requests for fetching pod,namespace and workload breakdown insights.
         logging.info(f"Received request to train model.")
+        training_data_count = (await es_instance.count(index="logs", body=model_logs_query_body))["count"]
         payload_query = {
             "max_size": max_logs_for_training,
             "query": model_logs_query_body,
+            "count": training_data_count,
         }
         try:
             await nw.publish("train", json.dumps(payload_query).encode())
+            logging.info(f"payload : {payload_query}")
             return b"submitted request to train model"
         except Exception as e:
             # Bad Request

--- a/training_controller/main.py
+++ b/training_controller/main.py
@@ -158,7 +158,7 @@ async def train_model():
         max_logs_for_training = PrepareTrainingLogs().get_num_logs_for_training()
         end_ts = int(time.time() * 1000)
         start_ts = end_ts - TRAINING_DATA_INTERVAL
-        parentheses_keywords = [f"({ANOMALY_KEYWORDS})"]
+        parentheses_keywords = [f"({x})" for x in ANOMALY_KEYWORDS]
         model_logs_query_body = {
             "query": {
                 "bool": {

--- a/training_controller/main.py
+++ b/training_controller/main.py
@@ -46,7 +46,7 @@ gpu_training_request = 0
 last_trainingjob_time = 0
 workload_parameters_dict = dict()
 GPU_GATEWAY_ENDPOINT = "http://opni-internal:11080/ModelTraining/gpu_info"
-TRAINING_DATA_INTERVAL = 3600 * 1000 * 24 # unit: ms. With introducing streaming data loader, it's possible to download much more training data.
+TRAINING_DATA_INTERVAL = 3600 * 1000 * 1 # unit: ms. With introducing streaming data loader, it's possible to download much more training data.
 ANOMALY_KEYWORDS = [
     "(error)",
     "(fail)",

--- a/training_controller/main.py
+++ b/training_controller/main.py
@@ -48,18 +48,18 @@ workload_parameters_dict = dict()
 GPU_GATEWAY_ENDPOINT = "http://opni-internal:11080/ModelTraining/gpu_info"
 TRAINING_DATA_INTERVAL = 3600 * 1000 * 1 # unit: ms. With introducing streaming data loader, it's possible to download much more training data.
 ANOMALY_KEYWORDS = [
-    "(error)",
-    "(fail)",
-    "(fatal)",
-    "(exception)",
-    "(timeout)",
-    "(unavailable)",
-    "(crash)",
-    "(connection refused)",
-    "(network error)",
-    "(deadlock)",
-    "(out of disk)",
-    "(high load)",
+    "error",
+    "fail",
+    "fatal",
+    "exception",
+    "timeout",
+    "unavailable",
+    "crash",
+    "connection refused",
+    "network error",
+    "deadlock",
+    "out of disk",
+    "high load",
 ]
 
 
@@ -168,7 +168,7 @@ async def train_model():
                         {"match": {"anomaly_level.keyword": "Anomaly"}},
                         {
                             "query_string": {
-                                "query": " or ".join(ANOMALY_KEYWORDS),
+                                "query": " or ".join(parentheses_keywords),
                                 "default_field": "log",
                             }
                         },


### PR DESCRIPTION
This PR removes the parentheses around the keywords in the ANOMALY_KEYWORDS list and instead will add them through list comprehension before being fed into the Opensearch query.