### PR TITLE
Update training controller service to reflect AIOps gateway plugin refactor

### DIFF
--- a/training_controller/main.py
+++ b/training_controller/main.py
@@ -108,9 +108,6 @@ async def get_nats_bucket_kv():
     model_training_bucket = await nw.get_bucket("model-training-parameters")
     current_bucket_payload = await model_training_bucket.get("modelTrainingParameters")
     last_trained_bucket_payload = await model_training_bucket.get("lastModelTrained")
-    test = await nw.get_bucket("model-training-statistics")
-    test_payload = await test.get("modelTrainingStatus")
-    json_result = json.loads(test_payload.decode())
     result_dict["current_workload_parameters"] = json.loads(
         current_bucket_payload.decode()
     )


### PR DESCRIPTION
This PR updates the training controller service to post a status message of "training failed" should the training controller service no longer be able to connect to the GPU controller service for training a workload Deep Learning model. Addresses https://github.com/rancher/opni/issues/1272