### PR TITLE
Set status of model to completed when watchlist is updated and no new model is training

### DIFF
--- a/training_controller/main.py
+++ b/training_controller/main.py
@@ -189,6 +189,7 @@ async def schedule_model_training():
             "model_workload_parameters", json.dumps(workload_parameter_payload).encode()
         )
         logging.info("Workload parameters have been updated for inferencing.")
+        post_model_status(status="completed")
 
 
 async def train_model(workload_parameters_dict):


### PR DESCRIPTION
This PR addresses https://github.com/rancher/opni/issues/1344 where if no new model is trained and the watchlist is simply being updated, it will set the status to completed. 